### PR TITLE
[AB2D-6174] Update accept header example

### DIFF
--- a/tutorial-curl.md
+++ b/tutorial-curl.md
@@ -221,7 +221,6 @@ opening ubuntu or some other terminal that supports curl and jq. See [Windows 10
    ```
    curl "https://sandbox.ab2d.cms.gov/api/v2/fhir/Patient/\$export?_outputFormat=application%2Ffhir%2Bndjson&_type=ExplanationOfBenefit" \
      -sD - \
-     -H "accept: application/json" \
      -H "Accept: application/fhir+json" \
      -H "Prefer: respond-async" \
      -H "Authorization: Bearer ${BEARER_TOKEN}"
@@ -320,7 +319,7 @@ opening ubuntu or some other terminal that supports curl and jq. See [Windows 10
    ```
    curl "https://sandbox.ab2d.cms.gov/api/v2/fhir/Job/${JOB}/\$status" \
      -sD - \
-     -H "accept: application/json" \
+     -H "Accept: application/json" \
      -H "Authorization: Bearer ${BEARER_TOKEN}"
    ```
    


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6174

## 🛠 Changes

Update the curl example for export endpoint with new accept header
Updates the styling of the example for status endpoint for consistency

## ℹ️ Context

As per the FHIR specification, we should be accepting content type of application/fhir+json by default on our export endpoint.

## 🧪 Validation

Changes tested locally
