### PR TITLE
Revert "[AB2D-6321] Update bundle with ruby 3.2.2 and update webrick to minimum 1.8.2"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,4 +34,4 @@ gem "wdm", "~> 0.1.0" if Gem.win_platform?
 gem 'jekyll-redirect-from', '>= 0.15.0'
 
 
-gem "webrick", "~> 1.8.2"
+gem "webrick", "~> 1.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,24 +1,24 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
     colorator (1.1.0)
-    concurrent-ruby (1.3.4)
-    em-websocket (0.5.3)
+    concurrent-ruby (1.1.8)
+    em-websocket (0.5.2)
       eventmachine (>= 0.12.9)
-      http_parser.rb (~> 0.8.0)
+      http_parser.rb (~> 0.6.0)
     eventmachine (1.2.7)
-    ffi (1.17.0-arm64-darwin)
+    ffi (1.15.0)
     forwardable-extended (2.6.0)
-    http_parser.rb (0.8.0)
-    i18n (1.14.6)
+    http_parser.rb (0.6.0)
+    i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jekyll (3.9.5)
+    jekyll (3.9.0)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
-      i18n (>= 0.7, < 2)
+      i18n (~> 0.7)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 2.0)
       kramdown (>= 1.17, < 3)
@@ -27,13 +27,13 @@ GEM
       pathutil (~> 0.9)
       rouge (>= 1.7, < 4)
       safe_yaml (~> 1.0)
-    jekyll-feed (0.17.0)
+    jekyll-feed (0.15.1)
       jekyll (>= 3.7, < 5.0)
     jekyll-redirect-from (0.16.0)
       jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
-    jekyll-seo-tag (2.8.0)
+    jekyll-seo-tag (2.7.1)
       jekyll (>= 3.8, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
@@ -41,33 +41,33 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    liquid (4.0.4)
-    listen (3.9.0)
+    liquid (4.0.3)
+    listen (3.5.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
-    minima (2.5.2)
+    minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (6.0.1)
-    rb-fsevent (0.11.2)
-    rb-inotify (0.11.1)
+    public_suffix (4.0.6)
+    rb-fsevent (0.10.4)
+    rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.3.8)
-    rouge (3.30.0)
+    rouge (3.26.0)
     safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    webrick (1.8.2)
+    webrick (1.8.1)
 
 PLATFORMS
-  arm64-darwin-23
+  arm64-darwin-21
   ruby
   x86_64-darwin-19
 
@@ -79,7 +79,7 @@ DEPENDENCIES
   minima (~> 2.5, >= 2.5.1)
   rexml (~> 3.3.6)
   tzinfo-data
-  webrick (~> 1.8.2)
+  webrick (~> 1.8)
 
 BUNDLED WITH
-   2.4.10
+   2.2.0


### PR DESCRIPTION
Reverts CMSgov/ab2d-website#57

Our deployment pipelines currently use Ruby 3.1.2, and will need to be updated to use 3.2.2 before we can implement this change.