### PR TITLE
[AB2D] [Dependabot] Update webrick minimum version to 1.8.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,4 +34,4 @@ gem "wdm", "~> 0.1.0" if Gem.win_platform?
 gem 'jekyll-redirect-from', '>= 0.15.0'
 
 
-gem "webrick", "~> 1.8"
+gem "webrick", "~> 1.8.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    webrick (1.8.1)
+    webrick (1.8.2)
 
 PLATFORMS
   arm64-darwin-21
@@ -79,7 +79,7 @@ DEPENDENCIES
   minima (~> 2.5, >= 2.5.1)
   rexml (~> 3.3.6)
   tzinfo-data
-  webrick (~> 1.8)
+  webrick (~> 1.8.2)
 
 BUNDLED WITH
    2.2.0


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6321

## 🛠 Changes

Update webrick minimum version to 1.8.2

## ℹ️ Context

Webrick library updated to a minimum version of 1.8.2 which patches a high severity security vulnerability caught by dependabot.

## 🧪 Validation

Tested locally. 
Deployed and tested on IMPL environment: https://dyx9tyg1h7v8p.cloudfront.net/
