### PR TITLE
Update understanding-ab2d-data.md

### DIFF
--- a/understanding-ab2d-data.md
+++ b/understanding-ab2d-data.md
@@ -31,7 +31,7 @@ active-nav: understanding-the-data-nav
                     </li>
                 </ul>
                 <p>
-                    These claims contain valuable information about enrollee health, which can help fill any gaps in the health records available to stand-alonePrescription Drug Plan (PDP) sponsors.
+                    These claims contain valuable information about enrollee health, which can help fill any gaps in the health records available to stand-alone Prescription Drug Plan (PDP) sponsors.
                 </p>
             </div>
             <div class="col-lg-6">


### PR DESCRIPTION
fixed typo to add space between "stand-alone" and "Prescription Drug Plan (PDP) sponsors." 

previously: stand-alonePrescription Drug Plan (PDP) sponsors 
new: stand-alone Prescription Drug Plan (PDP) sponsors

## 🎫 Ticket

no ticket made since this is such a small change

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
