### PR TITLE
AB2D-6408/BlastX team fix Tealium issues

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -33,12 +33,12 @@
 
     <!-- Within <head> of document below DataLayer snippet .
     The utag.sync.js script should run as early as possible -->
-    <script src="https://tealium-tags.cms.gov/cms-ab2d/qa/utag.sync.js"></script>
+    <script src="https://tealium-tags.cms.gov/cms-ab2d/prod/utag.sync.js"></script>
 
     <!-- Loading utag.js script asynchronously -->
     <script type="text/javascript">
         (function(a,b,c,d)
-            { a='https://tealium-tags.cms.gov/cms-ab2d/qa/utag.js'; b=document;c='script';d=b.createElement(c);d.src=a;d.type='text/java'+c;d.async=true; a=b.getElementsByTagName(c)[0];a.parentNode.insertBefore(d,a); }
+            { a='https://tealium-tags.cms.gov/cms-ab2d/prod/utag.js'; b=document;c='script';d=b.createElement(c);d.src=a;d.type='text/java'+c;d.async=true; a=b.getElementsByTagName(c)[0];a.parentNode.insertBefore(d,a); }
         )();
     </script>
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -33,12 +33,12 @@
 
     <!-- Within <head> of document below DataLayer snippet .
     The utag.sync.js script should run as early as possible -->
-    <script src="https://tealium-tags.cms.gov/cms-ab2d/dev/utag.sync.js"></script>
+    <script src="https://tealium-tags.cms.gov/cms-ab2d/qa/utag.sync.js"></script>
 
     <!-- Loading utag.js script asynchronously -->
     <script type="text/javascript">
         (function(a,b,c,d)
-            { a='https://tealium-tags.cms.gov/cms-ab2d/dev/utag.js'; b=document;c='script';d=b.createElement(c);d.src=a;d.type='text/java'+c;d.async=true; a=b.getElementsByTagName(c)[0];a.parentNode.insertBefore(d,a); }
+            { a='https://tealium-tags.cms.gov/cms-ab2d/qa/utag.js'; b=document;c='script';d=b.createElement(c);d.src=a;d.type='text/java'+c;d.async=true; a=b.getElementsByTagName(c)[0];a.parentNode.insertBefore(d,a); }
         )();
     </script>
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -33,12 +33,12 @@
 
     <!-- Within <head> of document below DataLayer snippet .
     The utag.sync.js script should run as early as possible -->
-    <script src="https://tealium-tags.cms.gov/cms-innovations/prod/utag.sync.js"></script>
+    <script src="https://tealium-tags.cms.gov/cms-ab2d/dev/utag.sync.js"></script>
 
-    <!-- Loading utag.sync.js script asynchronously -->
+    <!-- Loading utag.js script asynchronously -->
     <script type="text/javascript">
         (function(a,b,c,d)
-            { a='https://tealium-tags.cms.gov/cms-ab2d/prod/utag.sync.js'; b=document;c='script';d=b.createElement(c);d.src=a;d.type='text/java'+c;d.async=true; a=b.getElementsByTagName(c)[0];a.parentNode.insertBefore(d,a); }
+            { a='https://tealium-tags.cms.gov/cms-ab2d/dev/utag.js'; b=document;c='script';d=b.createElement(c);d.src=a;d.type='text/java'+c;d.async=true; a=b.getElementsByTagName(c)[0];a.parentNode.insertBefore(d,a); }
         )();
     </script>
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -35,10 +35,10 @@
     The utag.sync.js script should run as early as possible -->
     <script src="https://tealium-tags.cms.gov/cms-innovations/prod/utag.sync.js"></script>
 
-    <!-- Loading utag.js script asynchronously -->
+    <!-- Loading utag.sync.js script asynchronously -->
     <script type="text/javascript">
         (function(a,b,c,d)
-            { a='https://tealium-tags.cms.gov/cms-ab2d/prod/utag.js'; b=document;c='script';d=b.createElement(c);d.src=a;d.type='text/java'+c;d.async=true; a=b.getElementsByTagName(c)[0];a.parentNode.insertBefore(d,a); }
+            { a='https://tealium-tags.cms.gov/cms-ab2d/prod/utag.sync.js'; b=document;c='script';d=b.createElement(c);d.src=a;d.type='text/java'+c;d.async=true; a=b.getElementsByTagName(c)[0];a.parentNode.insertBefore(d,a); }
         )();
     </script>
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6408

## 🛠 Changes

Issue: The utag.sync.js code snippet is currently loading the cms-innovation profile.
Fix: Update the utag.sync.js code snippet to: <script src="https://tealium-tags.cms.gov/cms-ab2d/prod/utag.sync.js"></script> 

## ℹ️ Context

The BlastX team discovered a few issues with the Tealium code snippets on the [ab2d.cms.gov](http://ab2d.cms.gov/) subdomain in multiple environments.

## 🧪 Validation
dev: https://d2mq0f9b7t054b.cloudfront.net/
<img width="891" alt="Screenshot 2024-11-13 at 3 54 16 PM" src="https://github.com/user-attachments/assets/4153a565-6997-4b84-9927-7e6ba18259d9">
impl: https://dyx9tyg1h7v8p.cloudfront.net/
<img width="882" alt="Screenshot 2024-11-13 at 3 55 29 PM" src="https://github.com/user-attachments/assets/8a59bf14-80a4-43d1-bf31-290412536cfa">
