### PR TITLE
add privacy settings and sitemap to indentifier

### DIFF
--- a/_includes/identifier.html
+++ b/_includes/identifier.html
@@ -1,67 +1,54 @@
 <div class="usa-identifier">
-    <section
-      class="usa-identifier__section usa-identifier__section--masthead"
-      aria-label="Agency identifier,"
-    >
-      <div class="usa-identifier__container">
-        <div class="usa-identifier__logos">
-          <a href="https://www.hhs.gov/" class="usa-identifier__logo" data-tealium="identifier"
-            ><img
-              class="usa-identifier__logo-img"
-              src="{{ '/assets/img/HHS-logo.svg' | relative_url }}"
-              alt="HHS logo"
-              role="img"
-          /></a>
-          <a href="https://www.cms.gov/" class="usa-identifier__logo" data-tealium="identifier"
-            ><img
-              class="usa-identifier__logo-img padding-x-2"
-              src="{{ '/assets/img/CMS-logo.svg' | relative_url }}"
-              alt="CMS logo"
-              role="img"
-          /></a>
-        </div>
-        <section
-          class="usa-identifier__identity"
-          aria-label="Agency description,"
-        >
-          <p class="usa-identifier__identity-domain">cms.gov</p>
-          <p class="usa-identifier__identity-disclaimer">
-            <span aria-hidden="true">An </span>official website of the
-            <a href="https://www.hhs.gov/" class="usa-link--external">U.S. Department of Health and Human Services</a> and the
-            <a href="https://www.cms.gov/" class="usa-link--external">Centers for Medicare & Medicaid Services</a>.
-          </p>
-        </section>
+  <section class="usa-identifier__section usa-identifier__section--masthead" aria-label="Agency identifier,">
+    <div class="usa-identifier__container">
+      <div class="usa-identifier__logos">
+        <a href="https://www.hhs.gov/" class="usa-identifier__logo" data-tealium="identifier"><img
+            class="usa-identifier__logo-img" src="{{ '/assets/img/HHS-logo.svg' | relative_url }}" alt="HHS logo"
+            role="img" /></a>
+        <a href="https://www.cms.gov/" class="usa-identifier__logo" data-tealium="identifier"><img
+            class="usa-identifier__logo-img padding-x-2" src="{{ '/assets/img/CMS-logo.svg' | relative_url }}"
+            alt="CMS logo" role="img" /></a>
       </div>
-    </section>
-    <nav
-      class="usa-identifier__section usa-identifier__section--required-links"
-      aria-label="Important links,"
-    >
-      <div class="usa-identifier__container">
-        <ul class="usa-identifier__required-links-list">
-          {% for item in site.data.identifier-links %}
-          <li class="usa-identifier__required-links-item">
-            <a
-              href="{{ item.url }}" target="_blank" rel="noopener noreferrer"
-              data-tealium="identifier"
-              class="usa-identifier__required-link usa-link usa-link--external"
-              >{{ item.text }}</a
-            >
-          </li>
-          {% endfor %}
-        </ul>
+      <section class="usa-identifier__identity" aria-label="Agency description,">
+        <p class="usa-identifier__identity-domain">cms.gov</p>
+        <p class="usa-identifier__identity-disclaimer">
+          <span aria-hidden="true">An </span>official website of the
+          <a href="https://www.hhs.gov/" class="usa-link--external">U.S. Department of Health and Human Services</a> and
+          the
+          <a href="https://www.cms.gov/" class="usa-link--external">Centers for Medicare & Medicaid Services</a>.
+        </p>
+      </section>
+    </div>
+  </section>
+  <nav class="usa-identifier__section usa-identifier__section--required-links" aria-label="Important links,">
+    <div class="usa-identifier__container">
+      <ul class="usa-identifier__required-links-list">
+        {% for item in site.data.identifier-links %}
+        <li class="usa-identifier__required-links-item">
+          <a href="{{ item.url }}" target="_blank" rel="noopener noreferrer" data-tealium="identifier"
+            class="usa-identifier__required-link usa-link usa-link--external">{{ item.text }}</a>
+        </li>
+        {% endfor %}
+        <li class="usa-identifier__required-links-item">
+          <a class="usa-identifier__required-link usa-link" data-target="#privacyModal" href="#privacyModal"
+            data-privacy-policy="modal-trigger-footer" onclick="utag.gdpr.showConsentPreferences()">
+            Privacy Settings</a>
+        </li>
+        <li class="usa-identifier__required-links-item">
+          <a href="{{ '/sitemap' | relative_url }}" data-tealium="identifier"
+            class="usa-identifier__required-link usa-link">Sitemap</a>
+        </li>
+      </ul>
+    </div>
+  </nav>
+  <section class="usa-identifier__section usa-identifier__section--usagov"
+    aria-label="U.S. government information and services,">
+    <div class="usa-identifier__container">
+      <div class="usa-identifier__usagov-description">
+        Looking for U.S. government information and services?
       </div>
-    </nav>
-    <section
-      class="usa-identifier__section usa-identifier__section--usagov"
-      aria-label="U.S. government information and services,"
-    >
-      <div class="usa-identifier__container">
-        <div class="usa-identifier__usagov-description">
-          Looking for U.S. government information and services?
-        </div>
-        <a href="https://www.usa.gov/" class="usa-link usa-link--external" data-tealium="identifier">Visit USA.gov</a>
-      </div>
-    </section>
-  </div>
+      <a href="https://www.usa.gov/" class="usa-link usa-link--external" data-tealium="identifier">Visit USA.gov</a>
+    </div>
+  </section>
+</div>
 </footer>

--- a/_includes/identifier.html
+++ b/_includes/identifier.html
@@ -2,20 +2,21 @@
   <section class="usa-identifier__section usa-identifier__section--masthead" aria-label="Agency identifier,">
     <div class="usa-identifier__container">
       <div class="usa-identifier__logos">
-        <a href="https://www.hhs.gov/" class="usa-identifier__logo" data-tealium="identifier"><img
-            class="usa-identifier__logo-img" src="{{ '/assets/img/HHS-logo.svg' | relative_url }}" alt="HHS logo"
-            role="img" /></a>
-        <a href="https://www.cms.gov/" class="usa-identifier__logo" data-tealium="identifier"><img
-            class="usa-identifier__logo-img padding-x-2" src="{{ '/assets/img/CMS-logo.svg' | relative_url }}"
-            alt="CMS logo" role="img" /></a>
+        <a href="https://www.hhs.gov/" class="usa-identifier__logo" data-tealium="identifier">
+          <img class="usa-identifier__logo-img" src="{{ '/assets/img/HHS-logo.svg' | relative_url }}" alt="HHS logo"
+            role="img" />
+        </a>
+        <a href="https://www.cms.gov/" class="usa-identifier__logo" data-tealium="identifier">
+          <img class="usa-identifier__logo-img padding-x-2" src="{{ '/assets/img/CMS-logo.svg' | relative_url }}"
+            alt="CMS logo" role="img" />
+        </a>
       </div>
       <section class="usa-identifier__identity" aria-label="Agency description,">
         <p class="usa-identifier__identity-domain">cms.gov</p>
         <p class="usa-identifier__identity-disclaimer">
-          <span aria-hidden="true">An </span>official website of the
-          <a href="https://www.hhs.gov/" class="usa-link--external">U.S. Department of Health and Human Services</a> and
-          the
-          <a href="https://www.cms.gov/" class="usa-link--external">Centers for Medicare & Medicaid Services</a>.
+          <span aria-hidden="true">An</span>official website of the <a href="https://www.hhs.gov/"
+            class="usa-link--external">U.S. Department of Health and Human Services</a> and the <a
+            href="https://www.cms.gov/" class="usa-link--external">Centers for Medicare & Medicaid Services</a>.
         </p>
       </section>
     </div>
@@ -38,6 +39,10 @@
           <a href="{{ '/sitemap' | relative_url }}" data-tealium="identifier"
             class="usa-identifier__required-link usa-link">Sitemap</a>
         </li>
+        <li class="usa-identifier__required-links-item">
+          <a href="{{ '/status' | relative_url }}" data-tealium="identifier"
+            class="usa-identifier__required-link usa-link">API Status</a>
+        </li>
       </ul>
     </div>
   </nav>
@@ -51,4 +56,3 @@
     </div>
   </section>
 </div>
-</footer>


### PR DESCRIPTION
these are internal links and can't be added to the yml file

## 🎫 Ticket

Ad hoc spike 

## 🛠 Changes

Only change was the additional of two links to the identifier: `Sitemap` and `Privacy Settings`. These can't be entered in the yml file because they are internal links and/or have specific onclick values. The rest of changes are formatting. 

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
