### PR TITLE
[AB2D-6668] Update github actions to account for renaming uswds-redesign to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       deploy_path:
         description: "S3 directory deployment location"
-        default: "uswds-redesign"
+        default: "main"
   workflow_call:
     inputs:
       deploy_path:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       deploy_path:
         description: "S3 directory deployment location (e.g. s3://s3_bucket/deploy_path/)"
-        default: "uswds-redesign"
+        default: "main"
   workflow_call:
     inputs:
       deploy_path:

--- a/.github/workflows/push-dev.yml
+++ b/.github/workflows/push-dev.yml
@@ -3,7 +3,7 @@ name: push to dev
 on:
   push:
     branches:
-      - uswds-redesign
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{  github.ref }}
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   deploy:
     with:
-      deploy_path: "uswds-redesign"
+      deploy_path: "main"
     uses: ./.github/workflows/deploy.yml
     secrets: inherit
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,6 @@ on:
 jobs:
   deploy:
     with:
-      deploy_path: "uswds-redesign"
+      deploy_path: "main"
     uses: ./.github/workflows/promote.yml
     secrets: inherit


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6668

## 🛠 Changes

Update github actions to account for renaming uswds-redesign to main

## ℹ️ Context for reviewers

The working redesign branch `uswds-redesign` has been renamed to `main`, `main` was renamed to `legacy` to preserve the git history.

This update updates the GH Action scripts to now use `main` instead of `uswds-redesign`

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
