### PR TITLE
AB2D-6734: Re-enable Broken Link Check

### DIFF
--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -13,7 +13,8 @@ on:
 
 jobs:
   broken-link-check:
-    runs-on: ubuntu-latest
+    runs-on:
+      - codebuild-ab2d-website-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
       - name: "Checkout code"

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -3,11 +3,6 @@ name: "Broken Link Check"
 on:
   schedule:
     - cron: 0 0 * * 0
-  push:
-    paths:
-      - .github/workflows/broken-link-check.yml
-      - '**.md'
-      - '**.html'
   workflow_call:
   workflow_dispatch:
 

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -1,11 +1,19 @@
 name: "Broken Link Check"
 
 on:
-  workflow_call
+  schedule:
+    - cron: 0 0 * * 0
+  push:
+    paths:
+      - .github/workflows/broken-link-check.yml
+      - '**.md'
+      - '**.html'
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   broken-link-check:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
       - name: "Checkout code"
@@ -17,4 +25,4 @@ jobs:
         with:
           jobSummary: true
           fail: true
-          args: --no-progress --accept '200..=299, 401, 403, 405' ~/_[pages,layouts,includes]/**.[md,html]
+          args: --no-progress --accept '200..=299, 401, 403, 405' .

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -31,5 +31,5 @@ jobs:
     needs: deploy
     uses: ./.github/workflows/a11y-check.yml
 
-  # broken-link-check:
-  #   uses: ./.github/workflows/broken-link-check.yml
+  broken-link-check:
+    uses: ./.github/workflows/broken-link-check.yml

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,2 +1,5 @@
 file://*
 \$status$
+http://hl7.org/fhir/sid/us-mbi
+https://idm.cms.gov/oauth2/*
+https://bluebutton.cms.gov/assets/ig/ValueSet-claim-query-cd.html

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -2,4 +2,3 @@ file://*
 \$status$
 http://hl7.org/fhir/sid/us-mbi
 https://idm.cms.gov/oauth2/*
-https://bluebutton.cms.gov/assets/ig/ValueSet-claim-query-cd.html

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,2 @@
+file://*
+\$status$

--- a/_pages/claims-data-details.md
+++ b/_pages/claims-data-details.md
@@ -323,7 +323,7 @@ Extensions referring to identifiers will have the following structure:
                 }
             }
         ],
-        "system": “http://hl7.org/fhir/sid/us-mbi”,
+        "system": "http://hl7.org/fhir/sid/us-mbi",
         "value": "7S94E00AA00"
     }
 }

--- a/_pages/support.md
+++ b/_pages/support.md
@@ -111,7 +111,7 @@ How can we get additional data elements beyond what’s listed in the final rule
 
 {% capture a8AccordionContent %}
 <p>
- The “final” <a href="https://bluebutton.cms.gov/assets/ig/ValueSet-claim-query-cd.html" target="_blank" rel="noopener">query code</a> indicates a final bill for payment. This doesn’t necessarily mean the claim is finalized and complete. For example, it’s possible for a claim object with a “final” query code to be cancelled and resubmitted under a new claim ID.
+ The “final” <a href="https://bluebutton.cms.gov/resources/variables/claim_query_cd/" target="_blank" rel="noopener">query code</a> indicates a final bill for payment. This doesn’t necessarily mean the claim is finalized and complete. For example, it’s possible for a claim object with a “final” query code to be cancelled and resubmitted under a new claim ID.
  </p>
  <p>
 Every time you pull the data, you will get the latest version of a claim. Claim objects have a lastUpdated field, which represents when the data was last refreshed by the API. This shows when AB2D received the update, not when the update was submitted to Medicare. <a href="{{ '/claims-data-details' | relative_url }}#identifying-claims-and-claim-versions-2">Learn how to use lastUpdated and claim ID to identify a unique instance of a claim.</a>


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6734

## 🛠 Changes
- adds a lycheeignore file for those links we wouldn't expect to resolve
- adjusts broken link workflow to use the `ab2d-website` codebuild runner and simplifies the lychee invocation
- corrects example json to remove smartquotes for us-mbi reference
- updates bb2 static site reference for `Claim Query Code`

## ℹ️ Context for reviewers
Greenfield migration.

## ✅ Acceptance Validation
This change set should generally pass the updates broken link workflow that it re-introduces.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
