### PR TITLE
AB2D-7296 Update codebuild runner naming

### DIFF
--- a/.github/workflows/a11y-check.yml
+++ b/.github/workflows/a11y-check.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   a11y-check:
-    runs-on: codebuild-ab2d-website-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-website-non-prod-${{github.run_id}}-${{github.run_attempt}}
 
     steps:
       # Step 1: Checkout the repo

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -30,7 +30,7 @@ jobs:
     if: ${{ (inputs.env == 'prod' && github.event_name == 'workflow_dispatch') ||  github.event_name == 'schedule'  }}
     permissions:
       id-token: write
-    runs-on: codebuild-ab2d-website-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-website-non-prod-${{github.run_id}}-${{github.run_attempt}}
 
     steps:
       - name: Configure Prod AWS Credentials
@@ -63,7 +63,7 @@ jobs:
     if: ${{ (inputs.env == 'staging' && github.event_name == 'workflow_dispatch') || (inputs.env == 'staging' && github.event_name == 'pull_request')  }}
     permissions:
       id-token: write
-    runs-on: codebuild-ab2d-website-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-website-prod-${{github.run_id}}-${{github.run_attempt}}
     env:
       BASE_PATH: ${{ inputs.feature_path && format('feature/{0}/', inputs.feature_path) || '' }}
 

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -30,7 +30,7 @@ jobs:
     if: ${{ (inputs.env == 'prod' && github.event_name == 'workflow_dispatch') ||  github.event_name == 'schedule'  }}
     permissions:
       id-token: write
-    runs-on: codebuild-ab2d-website-non-prod-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-website-prod-${{github.run_id}}-${{github.run_attempt}}
 
     steps:
       - name: Configure Prod AWS Credentials
@@ -63,7 +63,7 @@ jobs:
     if: ${{ (inputs.env == 'staging' && github.event_name == 'workflow_dispatch') || (inputs.env == 'staging' && github.event_name == 'pull_request')  }}
     permissions:
       id-token: write
-    runs-on: codebuild-ab2d-website-prod-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-website-non-prod-${{github.run_id}}-${{github.run_attempt}}
     env:
       BASE_PATH: ${{ inputs.feature_path && format('feature/{0}/', inputs.feature_path) || '' }}
 

--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   comment-pr:
-    runs-on: codebuild-ab2d-website-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-website-non-prod-${{github.run_id}}-${{github.run_attempt}}
 
     steps:
       - name: Post or update comment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: codebuild-ab2d-website-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-website-non-prod-${{github.run_id}}-${{github.run_attempt}}
 
     steps:
       - name: Checkout

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: codebuild-ab2d-website-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-website-non-prod-${{github.run_id}}-${{github.run_attempt}}
 
     steps:
       - name: Configure AWS Credentials

--- a/pa11yci.ci.json
+++ b/pa11yci.ci.json
@@ -12,8 +12,7 @@
     "chromeLaunchConfig": {
       "args": [
         "--no-sandbox"
-      ],
-      "executablePath": "/usr/bin/google-chrome"
+      ]
     }
   },
   "timeout": 240000


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-7296

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->

CDAP introduced arm64 specific runners that are provisioned and named per environment.

Related: https://github.com/CMSgov/bcda-static-site/pull/339

Follows `non-prod` for `promote` as previously implemented: https://github.com/CMSgov/ab2d/pull/1745/changes#diff-e5ab57a220924d9818afbeee4bf25a06ebe32c416ff9b779fab1dd49da60265dR36

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation
These changes are validated by attempting a deploy from these branches. 
<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->